### PR TITLE
🐛fix bug in link mapping function

### DIFF
--- a/extensions/amp-smartlinks/0.1/linkmate.js
+++ b/extensions/amp-smartlinks/0.1/linkmate.js
@@ -42,7 +42,7 @@ export class Linkmate {
     /** @private {?number} */
     this.publisherID_ = linkmateOptions.publisherID;
 
-    /** @private {?string} */
+    /** @private {string} */
     this.linkAttribute_ = linkmateOptions.linkAttribute;
 
     /** @private {!Document|!ShadowRoot} */
@@ -133,7 +133,7 @@ export class Linkmate {
     // for later association with the response
     const postLinks = [];
     anchorList.forEach(anchor => {
-      const link = anchor[this.linkAttribute_];
+      const link = anchor.getAttribute(this.linkAttribute_);
       // If a link is already a Narrativ link.
       if (/shop-links.co/.test(link)) {
         // Check if amp flag is there. Add if necessary. Don't add to payload.
@@ -180,7 +180,7 @@ export class Linkmate {
     const mappings = [];
     this.anchorList_.forEach(anchor => {
       this.linkmateResponse_.forEach(smartLink => {
-        if (anchor[this.linkAttribute_] === smartLink['url']
+        if (anchor.getAttribute(this.linkAttribute_) === smartLink['url']
             && smartLink['auction_id']) {
           mappings.push({anchor, replacementUrl:
               `https://shop-links.co/${smartLink['auction_id']}/?amp=true`});

--- a/extensions/amp-smartlinks/0.1/linkmate.js
+++ b/extensions/amp-smartlinks/0.1/linkmate.js
@@ -177,16 +177,17 @@ export class Linkmate {
    * @public
    */
   mapLinks_() {
-    return this.linkmateResponse_.map(smartLink => {
-      return Array.prototype.slice.call(this.anchorList_)
-          .map(anchor => {
-            return {
-              anchor,
-              replacementUrl: anchor[this.linkAttribute_] === smartLink['url']
-                && smartLink['auction_id']
-                ? `https://shop-links.co/${smartLink['auction_id']}/?amp=true` : null,
-            };
-          });
-    })[0];
+    const mappings = [];
+    this.anchorList_.forEach(anchor => {
+      this.linkmateResponse_.forEach(smartLink => {
+        if (anchor[this.linkAttribute_] === smartLink['url']
+            && smartLink['auction_id']) {
+          mappings.push({anchor, replacementUrl:
+              `https://shop-links.co/${smartLink['auction_id']}/?amp=true`});
+        }
+      });
+    });
+
+    return mappings;
   }
 }

--- a/extensions/amp-smartlinks/0.1/test/test-linkmate.js
+++ b/extensions/amp-smartlinks/0.1/test/test-linkmate.js
@@ -35,9 +35,9 @@ const helpersFactory = env => {
 
       return new AmpSmartlinks(ampTag);
     },
-    createAnchor(href) {
+    createAnchor(linkOptions) {
       const anchor = win.document.createElement('a');
-      anchor.href = href;
+      anchor.setAttribute(linkOptions['attributeName'], linkOptions['link']);
 
       return anchor;
     },
@@ -79,9 +79,9 @@ describes.fakeWin('amp-smartlinks',
               linkmateOptions,
           );
           anchorList = [
-            'http://fakelink.example',
-            'http://fakelink2.example',
-            'https://examplelocklink.example/#locklink',
+            {attributeName: 'href', link: 'http://fakelink.example'},
+            {attributeName: 'href', link: 'http://fakelink2.example'},
+            {attributeName: 'href', link: 'https://examplelocklink.example/#locklink'},
           ].map(helpers.createAnchor);
         });
 
@@ -124,9 +124,9 @@ describes.fakeWin('amp-smartlinks',
 
           linkmate.anchorList_ = anchorList;
           const newAnchorList = [
-            'http://totallynewlink.example',
-            'http://fakelink2.example',
-            'https://examplelocklink.example/#locklink',
+            {attributeName: 'href', link: 'http://totallynewlink.example'},
+            {attributeName: 'href', link: 'http://fakelink2.example'},
+            {attributeName: 'href', link: 'https://examplelocklink.example/#locklink'},
           ].map(helpers.createAnchor);
 
           mockFetch
@@ -153,9 +153,9 @@ describes.fakeWin('amp-smartlinks',
           linkmate.anchorList_ = anchorList;
           linkmate.linkmateResponse_ = [{a: 'b'}];
           const newAnchorList = [
-            'http://totallynewlink.example',
-            'http://fakelink2.example',
-            'https://examplelocklink.example/#locklink',
+            {attributeName: 'href', link: 'http://totallynewlink.example'},
+            {attributeName: 'href', link: 'http://fakelink2.example'},
+            {attributeName: 'href', link: 'https://examplelocklink.example/#locklink'},
           ].map(helpers.createAnchor);
 
           mockFetch
@@ -251,9 +251,9 @@ describes.fakeWin('amp-smartlinks',
           );
 
           anchorList = [
-            'http://fakelink.example',
-            'http://fakelink2.example',
-            'https://examplelocklink.example/#locklink',
+            {attributeName: 'href', link: 'http://fakelink.example/'},
+            {attributeName: 'href', link: 'http://fakelink2.example/'},
+            {attributeName: 'href', link: 'https://examplelocklink.example/#locklink'},
           ].map(helpers.createAnchor);
         });
 
@@ -300,9 +300,9 @@ describes.fakeWin('amp-smartlinks',
           env.sandbox.spy(linkmate, 'buildLinksPayload_');
 
           anchorList = [
-            'http://fakelink.example',
-            'http://http://shop-links.co/999',
-            'https://examplelocklink.example/#locklink',
+            {attributeName: 'href', link: 'http://fakelink.example/'},
+            {attributeName: 'href', link: 'http://shop-links.co/999'},
+            {attributeName: 'href', link: 'https://examplelocklink.example/#locklink'},
           ].map(helpers.createAnchor);
 
           const expectedPayload = [{
@@ -322,15 +322,52 @@ describes.fakeWin('amp-smartlinks',
           env.sandbox.spy(linkmate, 'buildLinksPayload_');
 
           anchorList = [
-            'http://http://shop-links.co/999',
+            {attributeName: 'href', link: 'http://shop-links.co/999'},
           ].map(helpers.createAnchor);
 
-          const expectedAnchor = 'http://http//shop-links.co/999?amp=true';
+          const expectedAnchor = 'http://shop-links.co/999?amp=true';
 
           const linkPayload = linkmate.buildLinksPayload_(anchorList);
 
           expect(linkPayload).to.deep.equal([]);
           expect(anchorList[0].href).to.equal(expectedAnchor);
+        });
+
+        it('Should build payload from anchorList with custom selector', () => {
+          env.sandbox.spy(linkmate, 'buildLinksPayload_');
+
+          const linkmateOptions = {
+            exclusiveLinks: false,
+            publisherID: 999,
+            linkSelector: 'a[data-outbound-vars]',
+            linkAttribute: 'data-outbound-vars',
+          };
+          linkmate = new Linkmate(
+              env.ampdoc,
+              xhr,
+              linkmateOptions,
+          );
+
+          anchorList = [
+            {attributeName: 'data-outbound-vars', link: 'http://fakelink.example/'},
+            {attributeName: 'data-outbound-vars', link: 'http://fakelink2.example/'},
+            {attributeName: 'data-outbound-vars', link: 'https://examplelocklink.example/#locklink'},
+          ].map(helpers.createAnchor);
+
+          const expectedPayload = [{
+            'raw_url': 'http://fakelink.example/',
+            'exclusive_match_requested': false,
+          }, {
+            'raw_url': 'http://fakelink2.example/',
+            'exclusive_match_requested': false,
+          }, {
+            'raw_url': 'https://examplelocklink.example/#locklink',
+            'exclusive_match_requested': true,
+          }];
+
+          const linkPayload = linkmate.buildLinksPayload_(anchorList);
+
+          expect(linkPayload).to.deep.equal(expectedPayload);
         });
       });
 
@@ -381,15 +418,66 @@ describes.fakeWin('amp-smartlinks',
           );
 
           anchorList = [
-            'http://fakelink.example/',
-            'http://fakelink2.example/',
-            'http://fakelink2.example/',
-            'https://nonmonetizedlink.example/',
+            {attributeName: 'href', link: 'http://fakelink.example/'},
+            {attributeName: 'href', link: 'http://fakelink2.example/'},
+            {attributeName: 'href', link: 'http://fakelink2.example/'},
+            {attributeName: 'href', link: 'https://examplelocklink.example/#locklink'},
           ].map(helpers.createAnchor);
         });
 
         it('Should map API response to anchorList', () => {
           env.sandbox.spy(linkmate, 'mapLinks_');
+          const linkmateResponse = [{
+            'auction_id': '1661245605416735203',
+            'exclusive_match_requested': false,
+            'pub_id': 999,
+            'url': 'http://fakelink.example/',
+          }, {
+            'auction_id': '1667546956215651271',
+            'exclusive_match_requested': false,
+            'pub_id': 999,
+            'url': 'http://fakelink2.example/',
+          }];
+          linkmate.anchorList_ = anchorList;
+          linkmate.linkmateResponse_ = linkmateResponse;
+
+          const expectedMapping = [{
+            anchor: anchorList[0],
+            replacementUrl: `https://shop-links.co/${linkmateResponse[0]['auction_id']}/?amp=true`,
+          }, {
+            anchor: anchorList[1],
+            replacementUrl: `https://shop-links.co/${linkmateResponse[1]['auction_id']}/?amp=true`,
+          }, {
+            anchor: anchorList[2],
+            replacementUrl: `https://shop-links.co/${linkmateResponse[1]['auction_id']}/?amp=true`,
+          }];
+
+          const actualMapping = linkmate.mapLinks_();
+
+          expect(actualMapping).to.deep.equal(expectedMapping);
+        });
+
+        it('Should map API response to anchorList with attribute', () => {
+          env.sandbox.spy(linkmate, 'mapLinks_');
+
+          const linkmateOptions = {
+            exclusiveLinks: false,
+            publisherID: 999,
+            linkAttribute: 'data-outbound-vars',
+          };
+          linkmate = new Linkmate(
+              env.ampdoc,
+              xhr,
+              linkmateOptions,
+          );
+
+          anchorList = [
+            {attributeName: 'data-outbound-vars', link: 'http://fakelink.example/'},
+            {attributeName: 'data-outbound-vars', link: 'http://fakelink2.example/'},
+            {attributeName: 'data-outbound-vars', link: 'http://fakelink2.example/'},
+            {attributeName: 'data-outbound-vars', link: 'https://examplelocklink.example/#locklink'},
+          ].map(helpers.createAnchor);
+
           const linkmateResponse = [{
             'auction_id': '1661245605416735203',
             'exclusive_match_requested': false,

--- a/extensions/amp-smartlinks/0.1/test/test-linkmate.js
+++ b/extensions/amp-smartlinks/0.1/test/test-linkmate.js
@@ -383,7 +383,8 @@ describes.fakeWin('amp-smartlinks',
           anchorList = [
             'http://fakelink.example/',
             'http://fakelink2.example/',
-            'https://examplelocklink.example/#locklink',
+            'http://fakelink2.example/',
+            'https://nonmonetizedlink.example/',
           ].map(helpers.createAnchor);
         });
 
@@ -394,6 +395,11 @@ describes.fakeWin('amp-smartlinks',
             'exclusive_match_requested': false,
             'pub_id': 999,
             'url': 'http://fakelink.example/',
+          }, {
+            'auction_id': '1667546956215651271',
+            'exclusive_match_requested': false,
+            'pub_id': 999,
+            'url': 'http://fakelink2.example/',
           }];
           linkmate.anchorList_ = anchorList;
           linkmate.linkmateResponse_ = linkmateResponse;
@@ -403,10 +409,10 @@ describes.fakeWin('amp-smartlinks',
             replacementUrl: `https://shop-links.co/${linkmateResponse[0]['auction_id']}/?amp=true`,
           }, {
             anchor: anchorList[1],
-            replacementUrl: null,
+            replacementUrl: `https://shop-links.co/${linkmateResponse[1]['auction_id']}/?amp=true`,
           }, {
             anchor: anchorList[2],
-            replacementUrl: null,
+            replacementUrl: `https://shop-links.co/${linkmateResponse[1]['auction_id']}/?amp=true`,
           }];
 
           const actualMapping = linkmate.mapLinks_();


### PR DESCRIPTION
- Bug in mapping function was "randomly" mapping linkmate response to anchors. This meant we weren't replacing more than one href per page. 
- Use `getAttribute` when grabbing values from anchor tags to support custom selectors.